### PR TITLE
Introduce forced named parameters

### DIFF
--- a/Mapper Tests/Mapper_Tests.swift
+++ b/Mapper Tests/Mapper_Tests.swift
@@ -30,13 +30,14 @@ class Mapper_Tests: XCTestCase {
     
     func testInitWithDictionary() {
         let subject = Person.initWithDictionary(["name":"Alfred","age":70])!
+
         XCTAssertEqual(subject.age, 70, "Age is 70")
         XCTAssertEqual(subject.name, "Alfred", "Name is Alfred")
     }
     
     func testDeepInheritance() {
         let subject = MasterCriminal.new();
-        subject.fill(["nickname" : "Ra's al Ghul", "myth" : true, "name" : "???"])
+        subject.fill(with: ["nickname" : "Ra's al Ghul", "myth" : true, "name" : "???"])
         XCTAssertTrue(subject.myth, "Subject is a myth")
         XCTAssertEqual(subject.name, "???", "Name is unknown")
         XCTAssertEqual(subject.nickname, "Ra's al Ghul", "Nickname is \"Ra's al Ghul\"")
@@ -54,7 +55,7 @@ class Mapper_Tests: XCTestCase {
         XCTAssertEqual(subject.name, "Bruce Wayne", "Name is Bruce Wayne")
         XCTAssertEqual(subject.age, 55, "Bruce Wayne is 55 years old")
         
-        subject.fill(["name":"Batman", "age":0])
+        subject.fill(with: ["name":"Batman", "age":0])
         XCTAssertNotEqual(subject.name, "Bruce Wayne", "Name is not Bruce Wayne")
         XCTAssertEqual(subject.name, "Batman", "Name is Batman")
         XCTAssertEqual(subject.age, 0, "Batmans age is unknown")
@@ -108,7 +109,7 @@ class Mapper_Tests: XCTestCase {
             "attributes":[:],
             "archEnemy" : NSNull.new()])!
         
-        batman.fill(["name":[]])
+        batman.fill(with: ["name":[]])
     }
     
 }

--- a/Source/Mapper.swift
+++ b/Source/Mapper.swift
@@ -81,7 +81,7 @@ public extension NSObject {
     }
     
     class func initWithDictionary(dictionary :NSDictionary, dateFormat: DateFormat? = .ISO8601) -> Self? {
-        return self.init().fill(dictionary, dateFormat: dateFormat)
+        return self.init().fill(with: dictionary, dateFormat: dateFormat)
     }
     
     private func mirrorClass() -> AnyClass? {
@@ -116,7 +116,7 @@ public extension NSObject {
         return properties.copy() as! NSDictionary
     }
     
-    func fill(dictionary: NSDictionary, dateFormat: DateFormat? = .ISO8601) -> Self? {
+    func fill(with dictionary: NSDictionary, dateFormat: DateFormat? = .ISO8601) -> Self? {
         let propertyNames = self.propertyNames()
         let propertyTypes = self.propertyTypes()
         


### PR DESCRIPTION
Adding the named parameter `with` in the `fill` method would make the auto completion in Xcode look like this. Thoughts?

![screen shot 2015-03-04 at 14 34 31](https://cloud.githubusercontent.com/assets/57446/6484370/9e6a80ac-c27b-11e4-8b11-1b75a8a74061.PNG)

Making a named parameter is easy: 
`func fill(with dictionary: NSDictionary, dateFormat: DateFormat? = .ISO8601) -> Self? {`

`with` is the named parameters for the first parameter, if you wanted it to be dictionary, you would just prepend a # to the parameters in your declaration which would look like this.

`func fill(#dictionary: NSDictionary, dateFormat: DateFormat? = .ISO8601) -> Self? {`

Which would give you a completion that looks like this (but this example ended up pretty odd.

![screen shot 2015-03-04 at 14 44 23](https://cloud.githubusercontent.com/assets/57446/6484511/f7e6f2a4-c27c-11e4-9104-3d1e188d4c30.PNG)
